### PR TITLE
Remove "and calculation directives" from ExternalWorksheet docstring

### DIFF
--- a/src/types/external_worksheet.ts
+++ b/src/types/external_worksheet.ts
@@ -12,8 +12,8 @@ export type ExternalWorksheet = {
   /**
    * The cells belonging to the worksheet that have any data attached.
    *
-   * Typically, these will have only values attached as they will not be rendered by a spreadsheet
-   * application.
+   * Typically, these will have only values attached, as external worksheet cells serve purely as
+   * inputs to formulas in other sheets.
    */
   cells: Record<CellId, Cell>;
 };


### PR DESCRIPTION
Not clear what that was meant to convey, and “values” is enough