### PR TITLE
Support adding --tag for publishing pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,15 @@ jobs:
       - run: npm ci
       - run: npm run check
       - run: npm run build
-      - run: npm publish --access public
+      - name: Publish to npm
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [[ "$TAG" =~ -([a-zA-Z]+) ]]; then
+            DIST_TAG="${BASH_REMATCH[1]}"
+            npm publish --access public --tag "$DIST_TAG"
+          else
+            npm publish --access public
+          fi
   release:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
npm refuses to publish a pre-release version (any version containing a hyphen) without an explicit dist-tag, to prevent it from overwriting `latest`. Now our publish workflow uses a short, inline Bash script to detect a pre-release identifier and pass it as `--tag` to `npm publish`. Stable releases are published as they always have been (no dist-tag).