### PR TITLE
Add missing properties for roundtripping

### DIFF
--- a/src/types/Cell.ts
+++ b/src/types/Cell.ts
@@ -27,6 +27,11 @@ export type Cell = {
   /** The range of enclosing array if the formula is an array formula. */
   F?: string;
   /**
+   * True if the formula is a CSE (Ctrl+Shift+Enter) array formula rather
+   * than a dynamic array formula.
+   */
+  cse?: boolean;
+  /**
    * Cell hyperlink. Must be a URL.
    */
   l?: string;

--- a/src/types/tables/Table.ts
+++ b/src/types/tables/Table.ts
@@ -47,6 +47,12 @@ export type Table = {
    */
   headerRowCount?: integer;
   /**
+   * Whether the totals row is shown. When false, the totals row is hidden.
+   *
+   * @default true
+   */
+  totalsRowShown?: boolean;
+  /**
    * Presentation information for the table. When not present tables should be rendered using
    * `"TableStyleMedium2"` style with {@link TableStyle.showRowStripes} set to `true`.
    */

--- a/src/types/tables/TableColumn.ts
+++ b/src/types/tables/TableColumn.ts
@@ -23,4 +23,8 @@ export type TableColumn = {
    * If the column is a calculated column, then this field must include the formula used.
    */
   formula?: string;
+  /**
+   * When true, the calculated column formula is an array formula (CSE).
+   */
+  formulaIsArray?: boolean;
 };

--- a/src/types/tables/TableColumn.ts
+++ b/src/types/tables/TableColumn.ts
@@ -24,7 +24,7 @@ export type TableColumn = {
    */
   formula?: string;
   /**
-   * When true, the calculated column formula is an array formula (CSE).
+   * When true, the calculated column formula is an array formula.
    */
   formulaIsArray?: boolean;
 };


### PR DESCRIPTION
Add three properties needed for round-tripping fidelity from XLSX to JSF to XLSX:

- `Cell.cse` to distinguish a legacy CSE array formula from a dynamic array formula
- `Table.totalsRowShown` to convey that display of the totals row was turned off (default on)
- `TableColumn.formulaIsArray` to convey that a calculated column formula is an array formula