### PR TITLE
Add NamedStyle type and style inheritance

### DIFF
--- a/src/types/styles/NamedStyle.ts
+++ b/src/types/styles/NamedStyle.ts
@@ -1,0 +1,20 @@
+import type { integer } from '../integer.ts';
+import type { Style } from './Style.ts';
+
+/**
+ * A named cell style definition (e.g. "Normal", "Heading 1").
+ *
+ * In OOXML these correspond to `<cellStyle>` elements and their associated
+ * formatting records in `<cellStyleXfs>`.
+ *
+ * @group Workbooks
+ */
+export type NamedStyle = Style & {
+  /** The display name of the cell style (e.g. "Normal", "Heading 1"). */
+  name: string;
+  /**
+   * The OOXML built-in style identifier, if this is a built-in style.
+   * For example, 0 = Normal, 16 = Heading 1, etc.
+   */
+  builtinId?: integer;
+};

--- a/src/types/styles/Style.ts
+++ b/src/types/styles/Style.ts
@@ -163,8 +163,8 @@ export type Style = {
   numberFormat?: string;
   /**
    * Name of the named style this style inherits from (e.g. "Percent", "Heading 1").
-   * Refers to a {@link NamedStyle.name} in {@link Workbook.namedStyles}.
+   * Refers to a key in {@link Workbook.namedStyles}.
    * When absent, the style inherits from the default style (typically "Normal").
    */
-  parentStyle?: string;
+  extendsStyle?: string;
 };

--- a/src/types/styles/Style.ts
+++ b/src/types/styles/Style.ts
@@ -161,4 +161,10 @@ export type Style = {
    * Formatting directions for rendering the cell's value to text.
    */
   numberFormat?: string;
+  /**
+   * Name of the named style this style inherits from (e.g. "Percent", "Heading 1").
+   * Refers to a {@link NamedStyle.name} in {@link Workbook.namedStyles}.
+   * When absent, the style inherits from the default style (typically "Normal").
+   */
+  parentStyle?: string;
 };

--- a/src/types/styles/index.ts
+++ b/src/types/styles/index.ts
@@ -1,4 +1,5 @@
 export type * from './BorderStyle.ts';
+export type * from './NamedStyle.ts';
 export type * from './HAlign.ts';
 export type * from './PatternStyle.ts';
 export type * from './Style.ts';

--- a/src/types/workbooks/Workbook.ts
+++ b/src/types/workbooks/Workbook.ts
@@ -1,6 +1,7 @@
 import type { Person } from '../comments/index.ts';
 import type { DefinedName } from '../DefinedName.ts';
 import type { External } from '../External.ts';
+import type { NamedStyle } from '../styles/index.ts';
 import type { Style } from '../styles/index.ts';
 import type { Table } from '../tables/index.ts';
 import type { Theme } from '../themes/index.ts';
@@ -30,6 +31,8 @@ export type Workbook = {
   calculationProperties?: CalcProps;
   /** Styles for cells in the workbook. */
   styles?: Style[];
+  /** Named cell style definitions (e.g. "Normal", "Heading 1"). */
+  namedStyles?: NamedStyle[];
   /** External cells referenced by the workbook. An external cell is a cell in another workbook. */
   externals?: External[];
   /**

--- a/src/types/workbooks/Workbook.ts
+++ b/src/types/workbooks/Workbook.ts
@@ -31,8 +31,8 @@ export type Workbook = {
   calculationProperties?: CalcProps;
   /** Styles for cells in the workbook. */
   styles?: Style[];
-  /** Named cell style definitions (e.g. "Normal", "Heading 1"). */
-  namedStyles?: NamedStyle[];
+  /** Named cell style definitions (e.g. "Normal", "Heading 1"), keyed by style name. */
+  namedStyles?: Record<string, NamedStyle>;
   /** External cells referenced by the workbook. An external cell is a cell in another workbook. */
   externals?: External[];
   /**


### PR DESCRIPTION
## Summary
- Add `NamedStyle` type extending `Style` with `name` and optional `builtinId` (maps to OOXML `<cellStyle>` elements)
- Add `extendsStyle` property on `Style` for named style inheritance (e.g. inheriting from "Normal" or "Heading 1")
- Add `namedStyles` on `Workbook` as `Record<string, NamedStyle>`