### PR TITLE
Don't let a named style extend a named style

### DIFF
--- a/src/types/styles/NamedStyle.ts
+++ b/src/types/styles/NamedStyle.ts
@@ -7,9 +7,11 @@ import type { Style } from './Style.ts';
  * In OOXML these correspond to `<cellStyle>` elements and their associated
  * formatting records in `<cellStyleXfs>`.
  *
+ * Named styles don't extend other named styles.
+ *
  * @group Workbooks
  */
-export type NamedStyle = Style & {
+export type NamedStyle = Omit<Style, 'extendsStyle'> & {
   /** The display name of the cell style (e.g. "Normal", "Heading 1"). */
   name: string;
   /**


### PR DESCRIPTION
What
---

Omit the `extendsStyle` property in `NamedStyle`.

Why
---

Because OOXML seems to do so, see §18.8.45:

> **xfId (Format Id)**
> 
> For xf records contained in cellXfs this is the zero-based index of an xf record contained in cellStyleXfs corresponding to the cell style applied to the cell.
> 
> Not present for xf records contained in cellStyleXfs.

... and supporting such named extensions means extra work (recursive cascading to apply style properties, guarding against cycles, stitching up A ← B ← C when B is deleted, etc.)