### PR TITLE
Add External.alternateUrls for cloud-sourced externals

### DIFF
--- a/src/types/AlternateUrls.ts
+++ b/src/types/AlternateUrls.ts
@@ -1,0 +1,36 @@
+/**
+ * Alternate URLs for an external workbook — typically used when the source file
+ * lives in a cloud location (OneDrive, SharePoint). In XLSX, this corresponds to
+ * the `<xxl21:alternateUrls>` extension element inside `<externalBook>` (from
+ * the 2021 extlinks2021 namespace).
+ *
+ * `absoluteUrl`/`relativeUrl` are captured from child elements of
+ * `<xxl21:alternateUrls>`; `driveId`/`itemId` are attributes on the
+ * `<xxl21:alternateUrls>` element itself.
+ *
+ * At least one subfield must be set for the value to be meaningful; a purely
+ * empty `{}` is allowed by the type but producers and consumers should omit
+ * it in that case. Each subfield is independently optional per the xxl21
+ * schema.
+ *
+ * @group Workbooks
+ */
+export type AlternateUrls = {
+  /** Absolute URL to the external resource (e.g. a OneDrive web URL). */
+  absoluteUrl?: string;
+  /** Relative URL to the external resource. */
+  relativeUrl?: string;
+  /**
+   * OneDrive/SharePoint drive identifier Excel writes alongside cloud
+   * alternate URLs. Used by Microsoft Graph API calls to locate the
+   * container holding the external document, independent of the URL.
+   * Opaque string; round-tripped verbatim.
+   */
+  driveId?: string;
+  /**
+   * OneDrive/SharePoint item identifier — the resource-level counterpart
+   * to `driveId`; used by Microsoft Graph API calls to locate the external
+   * document itself. Opaque string; round-tripped verbatim.
+   */
+  itemId?: string;
+};

--- a/src/types/External.ts
+++ b/src/types/External.ts
@@ -23,4 +23,31 @@ export type External = {
    * In XLSX, this corresponds to the xlPathMissing relationship type.
    */
   pathMissing?: boolean;
+  /**
+   * Alternate URLs for the external workbook — typically used when the source file
+   * lives in a cloud location (OneDrive, SharePoint). In XLSX, this corresponds to
+   * the `<xxl21:alternateUrls>` extension element inside `<externalBook>` (from the
+   * 2021 extlinks2021 namespace), with each URL captured from the external-link part's
+   * rels entry that the extension's child element references.
+   *
+   * Both child kinds are optional per the OOXML schema; at most one of each may
+   * appear. When omitted, the roundtrip is a single-rel file-path external.
+   */
+  alternateUrls?: {
+    /** Absolute URL to the external resource (e.g. a OneDrive web URL). */
+    absoluteUrl?: string;
+    /** Relative URL to the external resource. */
+    relativeUrl?: string;
+    /**
+     * OneDrive/SharePoint drive identifier. Excel writes this alongside a
+     * cloud alternate URL so the client can reach the same document via the
+     * Graph API. Opaque string; we preserve it verbatim through the round-trip.
+     */
+    driveId?: string;
+    /**
+     * OneDrive/SharePoint item identifier. Same role as `driveId` —
+     * preserved verbatim for the round-trip.
+     */
+    itemId?: string;
+  };
 };

--- a/src/types/External.ts
+++ b/src/types/External.ts
@@ -1,3 +1,4 @@
+import type { AlternateUrls } from './AlternateUrls.ts';
 import type { ExternalDefinedName } from './ExternalDefinedName.ts';
 import type { ExternalWorksheet } from './ExternalWorksheet.ts';
 
@@ -24,37 +25,8 @@ export type External = {
    */
   pathMissing?: boolean;
   /**
-   * Alternate URLs for the external workbook — typically used when the source file
-   * lives in a cloud location (OneDrive, SharePoint). In XLSX, this corresponds to
-   * the `<xxl21:alternateUrls>` extension element inside `<externalBook>` (from the
-   * 2021 extlinks2021 namespace).
-   *
-   * `absoluteUrl`/`relativeUrl` are captured from child elements of
-   * `<xxl21:alternateUrls>`; `driveId`/`itemId` are attributes on the
-   * `<xxl21:alternateUrls>` element itself.
-   *
-   * At least one subfield must be set for the value to be meaningful; a purely
-   * empty `alternateUrls: {}` is allowed by the type but producers and consumers
-   * should omit it in that case. Each subfield is independently optional per the
-   * xxl21 schema.
+   * Alternate URLs for the external workbook (cloud-sourced externals). See
+   * {@link AlternateUrls}.
    */
-  alternateUrls?: {
-    /** Absolute URL to the external resource (e.g. a OneDrive web URL). */
-    absoluteUrl?: string;
-    /** Relative URL to the external resource. */
-    relativeUrl?: string;
-    /**
-     * OneDrive/SharePoint drive identifier Excel writes alongside cloud
-     * alternate URLs. Used by Microsoft Graph API calls to locate the
-     * container holding the external document, independent of the URL.
-     * Opaque string; round-tripped verbatim.
-     */
-    driveId?: string;
-    /**
-     * OneDrive/SharePoint item identifier — the resource-level counterpart
-     * to `driveId`; used by Microsoft Graph API calls to locate the external
-     * document itself. Opaque string; round-tripped verbatim.
-     */
-    itemId?: string;
-  };
+  alternateUrls?: AlternateUrls;
 };

--- a/src/types/External.ts
+++ b/src/types/External.ts
@@ -27,11 +27,16 @@ export type External = {
    * Alternate URLs for the external workbook — typically used when the source file
    * lives in a cloud location (OneDrive, SharePoint). In XLSX, this corresponds to
    * the `<xxl21:alternateUrls>` extension element inside `<externalBook>` (from the
-   * 2021 extlinks2021 namespace), with each URL captured from the external-link part's
-   * rels entry that the extension's child element references.
+   * 2021 extlinks2021 namespace).
    *
-   * Both child kinds are optional per the OOXML schema; at most one of each may
-   * appear. When omitted, the roundtrip is a single-rel file-path external.
+   * `absoluteUrl`/`relativeUrl` are captured from child elements of
+   * `<xxl21:alternateUrls>`; `driveId`/`itemId` are attributes on the
+   * `<xxl21:alternateUrls>` element itself.
+   *
+   * At least one subfield must be set for the value to be meaningful; a purely
+   * empty `alternateUrls: {}` is allowed by the type but producers and consumers
+   * should omit it in that case. Each subfield is independently optional per the
+   * xxl21 schema.
    */
   alternateUrls?: {
     /** Absolute URL to the external resource (e.g. a OneDrive web URL). */
@@ -39,14 +44,16 @@ export type External = {
     /** Relative URL to the external resource. */
     relativeUrl?: string;
     /**
-     * OneDrive/SharePoint drive identifier. Excel writes this alongside a
-     * cloud alternate URL so the client can reach the same document via the
-     * Graph API. Opaque string; we preserve it verbatim through the round-trip.
+     * OneDrive/SharePoint drive identifier Excel writes alongside cloud
+     * alternate URLs. Used by Microsoft Graph API calls to locate the
+     * container holding the external document, independent of the URL.
+     * Opaque string; round-tripped verbatim.
      */
     driveId?: string;
     /**
-     * OneDrive/SharePoint item identifier. Same role as `driveId` —
-     * preserved verbatim for the round-trip.
+     * OneDrive/SharePoint item identifier — the resource-level counterpart
+     * to `driveId`; used by Microsoft Graph API calls to locate the external
+     * document itself. Opaque string; round-tripped verbatim.
      */
     itemId?: string;
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+export type * from './AlternateUrls.ts';
 export type * from './Cell.ts';
 export type * from './CellId.ts';
 export type * from './CellRange.ts';


### PR DESCRIPTION
What
---

Add an optional `alternateUrls` field to `External`.

Captures the `<xxl21:alternateUrls>` extension that Excel writes on OneDrive/SharePoint-sourced externals:

- `absoluteUrl` / `relativeUrl` : URL strings (resolved by the parser from the child elements' `r:id` against the external-link part's rels)

- `driveId` / `itemId` : opaque OneDrive/SharePoint Graph-API pointers, round-tripped verbatim

Additive and non-breaking; existing consumers that don't know the field just ignore it.

Why
---

To enable roundtripping through JSF back to XLSX, there needs to be a place for these in the JSF.

Real-world impact of dropping these is user-visible: for cloud-sourced externals, losing the alternate URL means Excel can't refresh values from the source anymore (cached values still display, but "Edit Links → Update Values" fails silently), and losing `driveId`/`itemId` breaks Graph-API-based "open in web" and some co-authoring paths.