### PR TITLE
Add ExternalWorksheet.noSheetData marker

### DIFF
--- a/src/types/ExternalWorksheet.ts
+++ b/src/types/ExternalWorksheet.ts
@@ -25,12 +25,20 @@ export type ExternalWorksheet = {
   refreshError?: boolean;
   /**
    * Indicates that no `<sheetData>` element was recorded for this sheet in the source
-   * workbook, even though the sheet appears in `<sheetNames>`. The emitter should omit
-   * the `<sheetData>` entirely for such sheets rather than emit an empty one —
-   * `<sheetData sheetId="N"/>` (empty but present) and the absence of any sheetData
-   * element are distinct states under OOXML and producers rely on both.
+   * workbook, even though the sheet appears in `<sheetNames>`.
    *
-   * When set, `cells` is expected to be empty (`{}`) and `refreshError` unset.
+   * Emitter contract:
+   * - `undefined` (the common case): emit `<sheetData sheetId=N>` populated from `cells`.
+   * - `true`: omit the `<sheetData>` element entirely for this sheet.
+   *
+   * The distinction matters because `<sheetData sheetId="N"/>` (empty but present) and
+   * the absence of any `<sheetData>` element are distinct states under OOXML and
+   * producers rely on both.
+   *
+   * Invariant: when `noSheetData` is `true`, `cells` is expected to be empty (`{}`)
+   * and `refreshError` unset. The jsdoc documents the invariant; the type doesn't
+   * enforce it, and callers setting both risk silently losing `cells`/`refreshError`
+   * on emit.
    */
   noSheetData?: boolean;
 };

--- a/src/types/ExternalWorksheet.ts
+++ b/src/types/ExternalWorksheet.ts
@@ -27,18 +27,15 @@ export type ExternalWorksheet = {
    * Indicates that no `<sheetData>` element was recorded for this sheet in the source
    * workbook, even though the sheet appears in `<sheetNames>`.
    *
-   * Emitter contract:
-   * - `undefined` (the common case): emit `<sheetData sheetId=N>` populated from `cells`.
-   * - `true`: omit the `<sheetData>` element entirely for this sheet.
+   * - `undefined` (the common case) corresponds to `<sheetData sheetId=N>`
+   * - `true` corresponds to `<sheetData>` element being missing for this sheet.
    *
    * The distinction matters because `<sheetData sheetId="N"/>` (empty but present) and
-   * the absence of any `<sheetData>` element are distinct states under OOXML and
-   * producers rely on both.
+   * the absence of any `<sheetData>` element are distinct states under OOXML.
    *
-   * Invariant: when `noSheetData` is `true`, `cells` is expected to be empty (`{}`)
-   * and `refreshError` unset. The jsdoc documents the invariant; the type doesn't
-   * enforce it, and callers setting both risk silently losing `cells`/`refreshError`
-   * on emit.
+   * When `noSheetData` is `true`, `cells` is expected to be empty (`{}`) and
+   * `refreshError` unset. The jsdoc documents the invariant; the type doesn't enforce it,
+   * and callers setting both risk silently losing `cells`/`refreshError` on emit.
    */
   noSheetData?: boolean;
 };

--- a/src/types/ExternalWorksheet.ts
+++ b/src/types/ExternalWorksheet.ts
@@ -23,4 +23,14 @@ export type ExternalWorksheet = {
    * In XLSX, this corresponds to the refreshError="1" attribute on sheetData.
    */
   refreshError?: boolean;
+  /**
+   * Indicates that no `<sheetData>` element was recorded for this sheet in the source
+   * workbook, even though the sheet appears in `<sheetNames>`. The emitter should omit
+   * the `<sheetData>` entirely for such sheets rather than emit an empty one —
+   * `<sheetData sheetId="N"/>` (empty but present) and the absence of any sheetData
+   * element are distinct states under OOXML and producers rely on both.
+   *
+   * When set, `cells` is expected to be empty (`{}`) and `refreshError` unset.
+   */
+  noSheetData?: boolean;
 };


### PR DESCRIPTION
What
---

Add an optional `noSheetData` flag to `ExternalWorksheet`.

Distinguishes a sheet named in `<sheetNames>` but absent from `<sheetDataSet>` from one with an empty `<sheetData sheetId="N"/>`. Both are valid OOXML states, and round-tripping an XLSX file through a parser + an emitter needs this marker so the emitter knows which one to produce.

Why
---

Purely for byte-level roundtrip fidelity. No user-visible Excel impact: emitting an empty `<sheetData sheetId="N"/>` where the input had no element vs. the other way around is cosmetically different but behaviorally equivalent from Excel's perspective (no repair dialog, no refresh difference).

When set, `cells` is expected to be empty (`{}`) and `refreshError` unset; the invariant is jsdoc-documented rather than type-enforced to keep the addition minimal.