### PR TITLE
Add fullCalcOnLoad to CalcProps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsfkit/types",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "TypeScript types for JSF: a JSON spreadsheet representation",
   "license": "MIT",
   "type": "module",

--- a/src/types/workbooks/CalcProps.ts
+++ b/src/types/workbooks/CalcProps.ts
@@ -37,4 +37,16 @@ export type CalcProps = {
    * @defaultValue "auto"
    */
   calcMode?: 'auto' | 'autoNoTable' | 'manual';
+  /**
+   * Whether the consuming application should perform a full recalculation when the workbook is
+   * opened. Mirrors the OOXML `<calcPr fullCalcOnLoad="1"/>` attribute (ECMA-376 §18.2.2).
+   *
+   * Per the spec, a writer should set this when cached values may not reflect what the formulas
+   * would now produce, and clear it after a successful recalculation on load. Per the spec, a
+   * reader should suppress the full recalculation when {@link CalcProps.calcMode} is `"manual"` —
+   * manual mode takes precedence.
+   *
+   * @defaultValue false
+   */
+  fullCalcOnLoad?: boolean;
 };


### PR DESCRIPTION
What
---

Add a `fullCalcOnLoad?: boolean` field to `CalcProps` representing either of the two prescriptive recalc-on-load attributes on OOXML `<calcPr>` (ECMA-376 §18.2.2): `fullCalcOnLoad` (the writer's request) or `forceFullCalc` (which Excel sets after a calc-engine version bump).

Both signal the same consumer-side action (perform a full recalculation on load) so collapse them to a single field.

A converter from OOXML to JSF should set `fullCalcOnLoad: true` if either attribute is set; a converter from JSF to OOXML should emit `fullCalcOnLoad="1"`.

The doc string covers the spec rules a reader needs to know about: the writer's responsibility to clear the flag after a successful recalculation on load, and the suppression by `calcMode="manual"` (manual mode takes precedence per spec).

Why
---

To let JSF convey the instruction that the consuming application should perform a full recalculation when the workbook is opened.

Notes
---

Companion change in [borgar/xlsx-convert#72][1] reads the OOXML attributes and emits this field on `calculationProperties`.

[1]: https://github.com/borgar/xlsx-convert/pull/72