### PR TITLE
Add hideValuesRow field to PivotTable

### DIFF
--- a/src/types/pivotTables/PivotTable.ts
+++ b/src/types/pivotTables/PivotTable.ts
@@ -379,4 +379,17 @@ export type PivotTable = {
    * @default false
    */
   applyWidthHeightFormats?: boolean;
+
+  // --- Display options carried in the x14 extension ---
+
+  /**
+   * Whether the synthetic "Values" header row is hidden when the data axis sits
+   * on the column axis with multiple data fields. Excel emits this on the
+   * `<ext uri="{962EF5D1-...}">` x14 extension and only sets it on multi-data
+   * column-axis pivots whose layout intentionally suppresses the values row.
+   * Single-row, empty-axis, and single-data-field pivots leave it unset.
+   *
+   * @default false
+   */
+  hideValuesRow?: boolean;
 };

--- a/src/types/pivotTables/PivotTable.ts
+++ b/src/types/pivotTables/PivotTable.ts
@@ -380,14 +380,10 @@ export type PivotTable = {
    */
   applyWidthHeightFormats?: boolean;
 
-  // --- Display options carried in the x14 extension ---
-
   /**
-   * Whether the synthetic "Values" header row is hidden when the data axis sits
-   * on the column axis with multiple data fields. Excel emits this on the
-   * `<ext uri="{962EF5D1-...}">` x14 extension and only sets it on multi-data
-   * column-axis pivots whose layout intentionally suppresses the values row.
-   * Single-row, empty-axis, and single-data-field pivots leave it unset.
+   * Whether the synthetic "Values" header row is hidden. The synthetic header row appears when
+   * the data axis sits on the column axis with multiple data fields, and labels the data field
+   * column above the data values. Setting this to `true` suppresses that row.
    *
    * @default false
    */


### PR DESCRIPTION
What
---

Add `hideValuesRow?: boolean` to `PivotTable`.

This mirrors Excel's `<x14:pivotTableDefinition hideValuesRow="1"/>` extension element. Excel only emits this on multi-data column-axis pivots whose layout intentionally suppresses the synthetic "Values" header row; single-row, empty-axis, and single-data-field pivots leave it unset.

Why
---

To support round-tripping it correctly.