### PR TITLE
Style: add pivotButton property

### DIFF
--- a/src/types/styles/Style.ts
+++ b/src/types/styles/Style.ts
@@ -168,15 +168,10 @@ export type Style = {
    */
   extendsStyle?: string;
   /**
-   * Marks the cell as a pivot-table button header (the cell with the
-   * dropdown-arrow filter UI, e.g. "Row Labels" / "Column Labels"). Excel
-   * renders this distinctly from a regular text cell --- a small triangle
-   * is overlaid in the cell --- and the cell's xf record carries
-   * `pivotButton="1"` in OOXML.
+   * Whether the a cell should appear as a pivot-table button header (typically shown with a
+   * dropdown-arrow filter UI, e.g. on "Row Labels" / "Column Labels").
    *
-   * Set this only on cells inside a pivot table's frame (the
-   * row/column-labels headers). Generic cells with no pivot context
-   * should leave it unset.
+   * Should be set only on cell styles used in a pivot table's layout.
    */
   pivotButton?: boolean;
 };

--- a/src/types/styles/Style.ts
+++ b/src/types/styles/Style.ts
@@ -167,4 +167,16 @@ export type Style = {
    * When absent, the style inherits from the default style (typically "Normal").
    */
   extendsStyle?: string;
+  /**
+   * Marks the cell as a pivot-table button header (the cell with the
+   * dropdown-arrow filter UI, e.g. "Row Labels" / "Column Labels"). Excel
+   * renders this distinctly from a regular text cell --- a small triangle
+   * is overlaid in the cell --- and the cell's xf record carries
+   * `pivotButton="1"` in OOXML.
+   *
+   * Set this only on cells inside a pivot table's frame (the
+   * row/column-labels headers). Generic cells with no pivot context
+   * should leave it unset.
+   */
+  pivotButton?: boolean;
 };


### PR DESCRIPTION
What
---

Add an optional `pivotButton?: boolean` property on `Style` to mark pivot-table button headers, meaning the cells with the dropdown-arrow filter UI (e.g. "Row Labels" / "Column Labels").

Why
---

Excel renders these distinctly from regular text cells (a small triangle is overlaid in the cell) and the distinction lives on the cell's xf record in OOXML as `pivotButton="1"`. Without a way to represent the difference between an ordinary text cell and a pivot-button header cell, round-tripping through JSF loses that distinction, so the resulting workbook lacks the dropdown-arrow UI when opened in Excel.