### PR TITLE
Add page margins to Worksheet

### DIFF
--- a/src/types/worksheets/PageMargins.ts
+++ b/src/types/worksheets/PageMargins.ts
@@ -1,0 +1,19 @@
+/**
+ * Page margins for a worksheet, in inches. Used when printing or rendering print previews.
+ *
+ * @group Workbooks
+ */
+export type PageMargins = {
+  /** Left page margin, in inches. */
+  left: number;
+  /** Right page margin, in inches. */
+  right: number;
+  /** Top page margin, in inches. */
+  top: number;
+  /** Bottom page margin, in inches. */
+  bottom: number;
+  /** Header margin, in inches (distance from the top of the page to the header). */
+  header: number;
+  /** Footer margin, in inches (distance from the bottom of the page to the footer). */
+  footer: number;
+};

--- a/src/types/worksheets/Worksheet.ts
+++ b/src/types/worksheets/Worksheet.ts
@@ -4,6 +4,7 @@ import type { GridSize } from '../GridSize.ts';
 import type { Note } from '../Note.ts';
 import type { ThreadedComment } from '../comments/index.ts';
 import type { Drawing } from '../dml/Drawing.ts';
+import type { PageMargins } from './PageMargins.ts';
 import type { WorksheetDefaults } from './WorksheetDefaults.ts';
 import type { WorksheetView } from './WorksheetView.ts';
 
@@ -41,4 +42,9 @@ export type Worksheet = {
   views?: WorksheetView[];
   /** A list of drawings that appear in this worksheet. */
   drawings?: Drawing[];
+  /**
+   * Print/page-layout margins in inches. Used by applications that print the worksheet or render
+   * print previews. When absent, applications apply their own defaults.
+   */
+  pageMargins?: PageMargins;
 };

--- a/src/types/worksheets/Worksheet.ts
+++ b/src/types/worksheets/Worksheet.ts
@@ -45,6 +45,8 @@ export type Worksheet = {
   /**
    * Print/page-layout margins in inches. Used by applications that print the worksheet or render
    * print previews. When absent, applications apply their own defaults.
+   *
+   * @default { left: 0.7, right: 0.7, top: 0.75, bottom: 0.75, header: 0.3, footer: 0.3 }
    */
   pageMargins?: PageMargins;
 };

--- a/src/types/worksheets/index.ts
+++ b/src/types/worksheets/index.ts
@@ -1,3 +1,4 @@
+export type * from './PageMargins.ts';
 export type * from './Worksheet.ts';
 export type * from './WorksheetDefaults.ts';
 export type * from './WorksheetLayoutScales.ts';


### PR DESCRIPTION
What
---

Introduce a `PageMargins` type, and an optional `pageMargins?: PageMargins` field on `Worksheet`. Document a `@default` with Excel's canonical defaults: 0.7/0.7/0.75/0.75/0.3/0.3 in inches.

Why
---

Without a JSF field, OOXML's `<pageMargins>` is dropped on round-trip through JSF.

The `@default` documentation is the contract between writers and parsers:

- a consumer of JSF that observes the field absent should treat it as equivalent to those values
- a producer of JSF is free to normalise a canonical-default OOXML element back to absent, or vice versa
