### PR TITLE
fix: correct baseItem sentinel documentation

### DIFF
--- a/src/types/pivotTables/PivotDataField.ts
+++ b/src/types/pivotTables/PivotDataField.ts
@@ -40,7 +40,13 @@ export type PivotDataField = {
    * The index of the base item used for "show data as" calculations. Only meaningful when
    * {@link showDataAs} is set to a relative calculation mode.
    *
-   * @default 1048832 (0x100100, sentinel meaning "use the previous item")
+   * This is a zero-based item index, except these sentinel values have specific meanings:
+   *
+   * - `1048828` — "previous value": the item preceding this one along the base field's axis
+   * - `1048829` — "next value": the item following this one
+   * - `1048832` — "not set" / no base item; the schema default
+   *
+   * @default 1048832
    */
   baseItem?: integer;
   /** The number format code for this data field's values (e.g. `"General"`, `"#,##0"`). */


### PR DESCRIPTION
Fix wrong claim in the `baseItem` docstring: it claimed that the default 1048832 was the "use the previous item" sentinel, but it is the "(not set)" sentinel, meaning no base item.

The relative-position sentinel values that Excel actually writes are 1048828 for "(previous value)" and 1048829 for "(next value)".

Document all three.