### PR TITLE
Add PivotFormat.style and enable PivotTable.formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsfkit/types",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "TypeScript types for JSF: a JSON spreadsheet representation",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsfkit/types",
-  "version": "2.5.0",
+  "version": "2.4.0",
   "description": "TypeScript types for JSF: a JSON spreadsheet representation",
   "license": "MIT",
   "type": "module",

--- a/src/types/pivotTables/PivotFormat.ts
+++ b/src/types/pivotTables/PivotFormat.ts
@@ -1,3 +1,4 @@
+import type { Style } from '../styles/index.ts';
 import type { PivotArea } from './PivotArea.ts';
 
 /**
@@ -5,6 +6,11 @@ import type { PivotArea } from './PivotArea.ts';
  *
  * Each format pairs a {@link PivotFormat.pivotArea | pivotArea} that defines which cells the
  * format targets with an action indicating whether formatting is applied or blanked.
+ *
+ * Formats are the durable representation of user formatting on pivot output: a consumer
+ * re-resolves each format's area against the current layout and overlays its {@link style} on
+ * every repaint, so the formatting follows the targeted region (an item's data cells, the grand
+ * total row, ...) when the pivot reshapes, rather than sticking to cell coordinates.
  *
  * @group PivotTables
  */
@@ -17,4 +23,10 @@ export type PivotFormat = {
   action?: 'formatting' | 'blank';
   /** The pivot table region this format applies to. */
   pivotArea: PivotArea;
+  /**
+   * The formatting to overlay on the area's cells. Only the properties present apply; everything
+   * else on a cell is left as-is (the differential-format semantics of OOXML's `dxf`).
+   * Absent for `action: 'blank'`.
+   */
+  style?: Style;
 };

--- a/src/types/pivotTables/PivotTable.ts
+++ b/src/types/pivotTables/PivotTable.ts
@@ -6,6 +6,7 @@ import type { PivotDataField } from './PivotDataField.ts';
 import type { PivotField } from './PivotField.ts';
 import type { PivotFieldIndex } from './PivotFieldIndex.ts';
 import type { PivotFilter } from './PivotFilter.ts';
+import type { PivotFormat } from './PivotFormat.ts';
 import type { PivotPageField } from './PivotPageField.ts';
 import type { PivotRowColItem } from './PivotRowColItem.ts';
 import type { PivotTableLocation } from './PivotTableLocation.ts';
@@ -90,11 +91,13 @@ export type PivotTable = {
   colItems?: PivotRowColItem[];
   /** Presentation style for the pivot table. */
   style?: PivotTableStyle;
-  // formats and conditionalFormats are omitted for now: they depend on the differential
-  // formatting (dxf) table which doesn't exist in JSF yet, and the conditional formatting
-  // model is not finalized.
-  // /** Custom formatting applied to specific regions of the pivot table. */
-  // formats?: PivotFormat[];
+  /**
+   * Custom formatting applied to specific regions of the pivot table. Each format carries its
+   * differential style inline (see {@link PivotFormat.style}); there is no separate dxf table
+   * in JSF.
+   */
+  formats?: PivotFormat[];
+  // conditionalFormats is omitted for now: the conditional formatting model is not finalized.
   // /** Conditional formatting rules applied to pivot table regions. */
   // conditionalFormats?: PivotConditionalFormat[];
   /** Advanced filters applied to pivot fields. */

--- a/src/types/pivotTables/index.ts
+++ b/src/types/pivotTables/index.ts
@@ -33,7 +33,7 @@ export type * from './PivotFieldIndex.ts';
 export type * from './PivotFieldItem.ts';
 export type * from './PivotFilter.ts';
 export type * from './PivotFilterType.ts';
-// export type * from './PivotFormat.ts';
+export type * from './PivotFormat.ts';
 export type * from './PivotGroupBy.ts';
 export type * from './PivotItemType.ts';
 export type * from './PivotPageField.ts';


### PR DESCRIPTION
Enable `PivotTable.formats` and add `style?: Style` to `PivotFormat`, with each format's differential style inline.

JSF `Style` is already sparse (every property optional), which matches the differential-format semantics, so no separate dxf table is introduced; writers can dedupe inline styles into an OOXML `dxfs` table.

Document the area-tracking contract on `PivotFormat`: formats are re-resolved against the current layout, so formatting follows the targeted region rather than cell coordinates when the pivot reshapes.

Still defer `conditionalFormats`.