### PR TITLE
Add a shared differential-style list and index pivot formats into it

### DIFF
--- a/src/types/pivotTables/PivotFormat.ts
+++ b/src/types/pivotTables/PivotFormat.ts
@@ -30,5 +30,5 @@ export type PivotFormat = {
    *
    * @see {@link Workbook.diffStyles}
    */
-  dxfId?: integer;
+  diffStyleId?: integer;
 };

--- a/src/types/pivotTables/PivotFormat.ts
+++ b/src/types/pivotTables/PivotFormat.ts
@@ -1,4 +1,4 @@
-import type { Style } from '../styles/index.ts';
+import type { integer } from '../integer.ts';
 import type { PivotArea } from './PivotArea.ts';
 
 /**
@@ -8,7 +8,7 @@ import type { PivotArea } from './PivotArea.ts';
  * format targets with an action indicating whether formatting is applied or blanked.
  *
  * Formats are the durable representation of user formatting on pivot output: a consumer
- * re-resolves each format's area against the current layout and overlays its {@link style} on
+ * re-resolves each format's area against the current layout and overlays its differential style on
  * every repaint, so the formatting follows the targeted region (an item's data cells, the grand
  * total row, ...) when the pivot reshapes, rather than sticking to cell coordinates.
  *
@@ -24,9 +24,11 @@ export type PivotFormat = {
   /** The pivot table region this format applies to. */
   pivotArea: PivotArea;
   /**
-   * The formatting to overlay on the area's cells. Only the properties present apply; everything
-   * else on a cell is left as-is (the differential-format semantics of OOXML's `dxf`).
-   * Absent for `action: 'blank'`.
+   * Index of the differential style to overlay on the area's cells, into
+   * {@link Workbook.diffStyles}. Only the properties present in that style apply; everything else
+   * on a cell is left as-is. Absent for `action: 'blank'`.
+   *
+   * @see {@link Workbook.diffStyles}
    */
-  style?: Style;
+  dxfId?: integer;
 };

--- a/src/types/pivotTables/PivotTable.ts
+++ b/src/types/pivotTables/PivotTable.ts
@@ -92,9 +92,9 @@ export type PivotTable = {
   /** Presentation style for the pivot table. */
   style?: PivotTableStyle;
   /**
-   * Custom formatting applied to specific regions of the pivot table. Each format carries its
-   * differential style inline (see {@link PivotFormat.style}); there is no separate dxf table
-   * in JSF.
+   * Custom formatting applied to specific regions of the pivot table. Each format references a
+   * shared differential style by index (see {@link PivotFormat.diffStyleId} and
+   * {@link Workbook.diffStyles}).
    */
   formats?: PivotFormat[];
   // conditionalFormats is omitted for now: the conditional formatting model is not finalized.

--- a/src/types/workbooks/Workbook.ts
+++ b/src/types/workbooks/Workbook.ts
@@ -31,6 +31,24 @@ export type Workbook = {
   calculationProperties?: CalcProps;
   /** Styles for cells in the workbook. */
   styles?: Style[];
+  /**
+   * Differential styles: partial style overrides referenced by index from features that overlay
+   * formatting on top of a cell's own style rather than replacing it (pivot table formats, custom
+   * table styles, and future dynamic/conditional styles).
+   *
+   * This is the differential-overlay analog of {@link Workbook.styles}: where {@link Cell.s}
+   * indexes a complete cell style in `styles`, an overlay's `dxfId` indexes a partial override
+   * here. Only the properties present in an entry apply; everything else on the target cell is
+   * left as-is.
+   *
+   * Each entry reuses the {@link Style} type (already all-optional), but is interpreted
+   * differentially: an absent property means "leave unchanged", not "use the default".
+   *
+   * The property name is provisional and may change before this is finalized.
+   *
+   * @see {@link PivotFormat.dxfId}
+   */
+  diffStyles?: Style[];
   /** Named cell style definitions (e.g. "Normal", "Heading 1"), keyed by style name. */
   namedStyles?: Record<string, NamedStyle>;
   /** External cells referenced by the workbook. An external cell is a cell in another workbook. */

--- a/src/types/workbooks/Workbook.ts
+++ b/src/types/workbooks/Workbook.ts
@@ -37,16 +37,14 @@ export type Workbook = {
    * table styles, and future dynamic/conditional styles).
    *
    * This is the differential-overlay analog of {@link Workbook.styles}: where {@link Cell.s}
-   * indexes a complete cell style in `styles`, an overlay's `dxfId` indexes a partial override
-   * here. Only the properties present in an entry apply; everything else on the target cell is
-   * left as-is.
+   * indexes a complete cell style in `styles`, an overlay's `diffStyleId` indexes a partial
+   * override here. Only the properties present in an entry apply; everything else on the target
+   * cell is left as-is.
    *
    * Each entry reuses the {@link Style} type (already all-optional), but is interpreted
    * differentially: an absent property means "leave unchanged", not "use the default".
    *
-   * The property name is provisional and may change before this is finalized.
-   *
-   * @see {@link PivotFormat.dxfId}
+   * @see {@link PivotFormat.diffStyleId}
    */
   diffStyles?: Style[];
   /** Named cell style definitions (e.g. "Normal", "Heading 1"), keyed by style name. */


### PR DESCRIPTION
What
---

Introduce a shared, workbook-level list of differential (partial) styles, referenced by index, as the single home for formatting that overlays a cell's own style instead of replacing it.

- Add `Workbook.diffStyles?: Style[]` — an ordered list of partial style overrides. Only the properties present in an entry apply; everything else on the target cell is left as-is. It reuses the existing, already all-optional `Style` type.
- Change `PivotFormat` to reference an entry by index: the inline `style` is replaced by `diffStyleId?: integer` (an index into `Workbook.diffStyles`).

Why
---

Several features overlay formatting on top of a cell's own style rather than replacing it: pivot table formats today, custom table styles (#54) and dynamic/conditional styles later. They all want the same kind of partial override, and they want to share entries rather than each carrying its own inline copy. A single shared list referenced by index models this directly, mirroring how cells already work — `Cell.s` indexes `Workbook.styles`, and now `diffStyleId` indexes `Workbook.diffStyles`. This is the foundation the other overlay features build on, so it lands first on its own.

This replaces the inline `PivotFormat.style` added in #53. Nothing consumes that field yet, so it is a clean replacement.

Design notes
---

- `diffStyles` reuses `Style` rather than introducing a separate `DiffStyle` type: `Style` is already entirely optional, so it is structurally exactly what a partial override needs. The differential reading — an absent property means "leave unchanged", not "use the default" — comes from the list an entry lives in.
- `diffStyleId` is a plain index; the first entry is index `0`. There is no implicit default entry (unlike `Cell.s`, where `0` is the default cell style), and an absent `diffStyleId` means "no overlay".

Open question
---

How should a pivot format that explicitly *blanks* formatting be encoded? This PR keeps the existing convention: `PivotFormat.action: 'blank'` with no `diffStyleId`. An alternative would be a dedicated empty entry referenced like any other. Feedback welcome.

Follow-ups (not in this PR)
---

- Rework #54 (custom table styles) onto this list — `TableStyleElement` referencing `diffStyleId` instead of an inline style (prototyped locally).
- The converters then emit/parse `diffStyles`, resolve the index references, and dedup equal entries into one shared list.
